### PR TITLE
Add initialization PowerShell scripts

### DIFF
--- a/FluentMigrator.Generator.nuspec
+++ b/FluentMigrator.Generator.nuspec
@@ -19,5 +19,7 @@
   </metadata>
   <files>
     <file src="FluentMigrator.psm1" target="tools" />
+    <file src="FluentMigrator.psd1" target="tools" />
+    <file src="init.ps1" target="tools" />
   </files>
 </package>

--- a/FluentMigrator.psd1
+++ b/FluentMigrator.psd1
@@ -1,0 +1,79 @@
+@{
+    # Script module or binary module file associated with this manifest
+    ModuleToProcess = 'FluentMigrator.psm1'
+
+    # Version number of this module.
+    ModuleVersion = '1.0.0.0'
+
+    # ID used to uniquely identify this module
+    GUID = '01820234-1d7c-4b25-8d01-a9d5e108f77b'
+
+    # Author of this module
+    Author = 'Ritter Insurance Marketing'
+
+    # Company or vendor of this module
+    CompanyName = 'Ritter Insurance Marketing'
+
+    # Copyright statement for this module
+    Copyright = '(c) Ritter Insurance Marketing, LLC. All rights reserved.'
+
+    # Description of the functionality provided by this module
+    Description = 'FluentMigrator PowerShell module for use within NuGet''s Package Manager Console'
+
+    # Minimum version of the Windows PowerShell engine required by this module
+    PowerShellVersion = '2.0'
+
+    # Name of the Windows PowerShell host required by this module
+    PowerShellHostName = 'Package Manager Host'
+
+    # Minimum version of the Windows PowerShell host required by this module
+    PowerShellHostVersion = '1.2'
+
+    # Minimum version of the .NET Framework required by this module
+    DotNetFrameworkVersion = '4.0'
+
+    # Minimum version of the common language runtime (CLR) required by this module
+    CLRVersion = ''
+
+    # Processor architecture (None, X86, Amd64, IA64) required by this module
+    ProcessorArchitecture = ''
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules = @()
+
+    # Assemblies that must be loaded prior to importing this module
+    RequiredAssemblies = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module
+    ScriptsToProcess = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    FormatsToProcess = @()
+
+    # Modules to import as nested modules of the module specified in ModuleToProcess
+    NestedModules = @()
+
+    # Functions to export from this module
+    FunctionsToExport = '*'
+
+    # Cmdlets to export from this module
+    CmdletsToExport = ''
+
+    # Variables to export from this module
+    VariablesToExport = '*'
+
+    # Aliases to export from this module
+    AliasesToExport = ''
+
+    # List of all modules packaged with this module
+    ModuleList = @()
+
+    # List of all files packaged with this module
+    FileList = @()
+
+    # Private data to pass to the module specified in ModuleToProcess
+    PrivateData = ''
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# FluentMigrator.Generator
+
+

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,8 @@
+param($installPath, $toolsPath, $package)
+
+if (Get-Module | ?{ $_.Name -eq "FluentMigrator" })
+{
+    Remove-Module FluentMigrator
+}
+
+Import-Module (Join-Path $toolsPath "FluentMigrator.psd1


### PR DESCRIPTION
`init.ps1` is necessary to install import the module defined in `FluentMigrator.psm1`.
