### PR TITLE
Opening parenthesis should have closing parenthesis

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -5,4 +5,4 @@ if (Get-Module | ?{ $_.Name -eq "FluentMigrator" })
     Remove-Module FluentMigrator
 }
 
-Import-Module (Join-Path $toolsPath "FluentMigrator.psd1"
+Import-Module (Join-Path $toolsPath "FluentMigrator.psd1")


### PR DESCRIPTION
Because a PR per character is the ultimate pair programming.
