### PR TITLE
Putting timestamp in migration class' name

### DIFF
--- a/FluentMigrator.psm1
+++ b/FluentMigrator.psm1
@@ -23,7 +23,9 @@ function Add-FluentMigration
     
     # if the $name parameter contains a string '{T}', then replace it with the timestamp but with a underscore between the
     # yyyyMMdd part and the HHmmss part
-    $name = [System.String]::Replace($name, "{T}", $class_name_timestamp)
+    if ($AddTimeStampToClassName) {
+        $name = [System.String]::Replace($name, "{T}", $class_name_timestamp)   
+    }
 
     $namespace = $project.Properties.Item("DefaultNamespace").Value.ToString() + ".Migrations"
     $projectPath = [System.IO.Path]::GetDirectoryName($project.FullName)

--- a/FluentMigrator.psm1
+++ b/FluentMigrator.psm1
@@ -5,8 +5,10 @@ function Add-FluentMigration
         [parameter(Position = 0,
             Mandatory = $true)]
         [string] $Name,
-        [string] $ProjectName)
+        [string] $ProjectName,
+        [switch] $AddTimeStampToClassName)
     $timestamp = (Get-Date -Format yyyyMMddHHmmss)
+    $class_name_timestamp = (Get-Date -Format yyyyMMdd_HHmmss)
 
     if ($ProjectName) {
         $project = Get-Project $ProjectName
@@ -18,6 +20,11 @@ function Add-FluentMigration
     else {
         $project = Get-Project
     }
+    
+    # if the $name parameter contains a string '{T}', then replace it with the timestamp but with a underscore between the
+    # yyyyMMdd part and the HHmmss part
+    $name = [System.String]::Replace($name, "{T}", $class_name_timestamp)
+
     $namespace = $project.Properties.Item("DefaultNamespace").Value.ToString() + ".Migrations"
     $projectPath = [System.IO.Path]::GetDirectoryName($project.FullName)
     $migrationsPath = [System.IO.Path]::Combine($projectPath, "Migrations")


### PR DESCRIPTION
Need to add an ability to put the timestamp directly in the name of the migration class itself.