### PR TITLE
Update FluentMigrator dependency version range

### DIFF
--- a/FluentMigrator.Generator.nuspec
+++ b/FluentMigrator.Generator.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>FluentMigrator.Generator</id>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <authors>Ritter Insurance Marketing, LLC</authors>
     <projectUrl>https://github.com/ritterim/fluentmigrator-generator</projectUrl>
     <licenseUrl>https://raw.githubusercontent.com/ritterim/fluentmigrator-generator/master/LICENSE</licenseUrl>
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <tags>fluentmigrator migrations</tags>
     <dependencies>
-      <dependency id="FluentMigrator" version="[1,2)" />
+      <dependency id="FluentMigrator" version="[1,4)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This updates the range of the `FluentMigrator` dependency to allow it to work with newer versions of `FluentMigrator` in addition this bumps the version of `fluentmigrator-generator`.